### PR TITLE
No or in where exp

### DIFF
--- a/docs/research/publications/data-access-tools.md
+++ b/docs/research/publications/data-access-tools.md
@@ -5,20 +5,20 @@ title: Data Access Tools
 
 These tools have been developed to help you discover and re-use eReefs data products:
 
-<center>
+<div class="tilegroup">
 {% for tool in site.tools %}{% if tool.category == "data-access" and tool.status != "decommissioned" %}
 <div class="tile {{tool.agency}} {{tool.category}}" markdown="0">
   <a href="{{tool.target_url}}" target="_window" title="Navigate to {{tool.title}}">
     <i class="fas fa-{{tool.fa-icon}}"></i>
     <h2>{{tool.title}}</h2>
     {{tool.caption | markdownify}}
-    <img alt="TODO: Preview of {{tool.title}}" src="{{tool.preview_image}}" />
+    <img alt="Preview of {{tool.title}}" src="{{tool.preview_image}}" />
   </a>
 </div>
 {% endif %}{% endfor %}
-</center>
+</div>
 
-<center>
+<div class="tilegroup">
 {% for tool in site.tools %}{% if tool.category == "tutorial" and tool.status != "decommissioned" %}
 <div class="tile {{tool.agency}} {{tool.category}}" markdown="0">
   <a href="{{tool.target_url}}" target="_window" title="Navigate to {{tool.title}}">
@@ -28,4 +28,4 @@ These tools have been developed to help you discover and re-use eReefs data prod
   </a>
 </div>
 {% endif %}{% endfor %}
-</center>
+</div>

--- a/docs/research/publications/software.md
+++ b/docs/research/publications/software.md
@@ -5,7 +5,7 @@ title: Open Source Software
 
 The following open-source software has been produced by the eReefs research teams and is available for re-use in other applications:
 
-<center>
+<div class="tilegroup">
 {% for tool in site.tools %}{% if tool.category == "software" and tool.status != "decommissioned" %}
 <div class="tile {{tool.agency}} {{tool.category}}" markdown="0">
   <a href="{{tool.target_url}}" target="_window" title="Navigate to {{tool.title}}">
@@ -15,4 +15,4 @@ The following open-source software has been produced by the eReefs research team
   </a>
 </div>
 {% endif %}{% endfor %}
-</center>
+</div>

--- a/docs/research/publications/web-applications.md
+++ b/docs/research/publications/web-applications.md
@@ -19,7 +19,7 @@ These web applications are the main interactive components of the *eReefs* web p
     <i class="fas fa-{{tool.fa-icon}}"></i>
     <h2>{{tool.title}}</h2>
     {{tool.caption | markdownify}}
-    <img alt="TODO: Preview of {{tool.title}}" src="{{tool.preview_image}}" />
+    <img alt="Preview of {{tool.title}}" src="{{tool.preview_image}}" />
   </a>
 </div>
 {% endfor %}

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -65,14 +65,25 @@ Our featured eReefs datasets are:
 These tools have been developed to help you discover and re-use *eReefs* data products:
 
 <div class="tilegroup">
-{% assign data_access_tools = active_tools | where_exp: "item", "item.category == 'data-access' or item.category == 'tutorial'" %}
+{% assign data_access_tools = active_tools | where_exp: "item", "item.category == 'data-access'" %}
 {% for tool in data_access_tools %}
 <div class="tile {{tool.agency}} {{tool.category}}" markdown="0">
   <a href="{{tool.target_url}}" target="_window" title="Navigate to {{tool.title}}">
     <i class="fas fa-{{tool.fa-icon}}"></i>
     <h2>{{tool.title}}</h2>
     {{tool.caption | markdownify}}
-    {% if tool.preview_image %}<img alt="TODO: Preview of {{tool.title}}" src="{{tool.preview_image}}" />{% endif %}
+    {% if tool.preview_image %}<img alt="Preview of {{tool.title}}" src="{{tool.preview_image}}" />{% endif %}
+  </a>
+</div>
+{% endfor %}
+{% assign tutorials = active_tools | where_exp: "item", "item.category == 'tutorial'" %}
+{% for tool in tutorials %}
+<div class="tile {{tool.agency}} {{tool.category}}" markdown="0">
+  <a href="{{tool.target_url}}" target="_window" title="Navigate to {{tool.title}}">
+    <i class="fas fa-{{tool.fa-icon}}"></i>
+    <h2>{{tool.title}}</h2>
+    {{tool.caption | markdownify}}
+    {% if tool.preview_image %}<img alt="Preview of {{tool.title}}" src="{{tool.preview_image}}" />{% endif %}
   </a>
 </div>
 {% endfor %}


### PR DESCRIPTION
Hopefully fix glitch in Jekyll parsing of https://github.com/eReefs/ereefs.github.io/pull/72
GitHub Pages uses Jekyll version 3.10.0 (from https://pages.github.com/versions/), but the `or` operator is not valid in liquid `where_exp` filters until Jekyll 4 (from https://stackoverflow.com/questions/42722902/and-or-on-a-where-exp-expression-on-jekyll )