### PR TITLE
Broken impact link fix and other very minor tweaks

### DIFF
--- a/docs/assets/css/ereefs-overrides.css
+++ b/docs/assets/css/ereefs-overrides.css
@@ -75,6 +75,9 @@
    left: 0;
    box-shadow: 0px 0px 4em 1em #ffffff;
 }
+.page__hero--overlay .page__title {
+   font-size: 2.5rem !important;
+}
 @media (min-width: 64em) {
    .layout--single .page__hero--overlay .page__title {
       margin-left: 200px;
@@ -82,6 +85,7 @@
 }
 @media (min-width: 80em) {
    .layout--single .page__hero--overlay .page__title {
+      font-size: 3.5rem !important;
       margin-left: 300px;
    }
    .page__hero--overlay .wrapper {

--- a/docs/assets/css/home.css
+++ b/docs/assets/css/home.css
@@ -27,6 +27,11 @@
 .title-text {
     font-size: 2.5rem !important;
 }
+@media (min-width: 80em) {
+    .title-text {
+       font-size: 3.5rem !important;
+    }
+}
 
 .subtitle-text{
     font-size: 1.5rem !important;
@@ -35,8 +40,8 @@
 .image-vignette {
     max-height: 50vh;
     min-height: 35vh;
- 
-    width:auto; 
+
+    width:auto;
     object-fit:cover;
 }
 
@@ -215,7 +220,7 @@ display: block;
     .title-text {
         font-size: 2rem !important;
     }
-    
+
     .subtitle-text{
         font-size: 1rem !important;
     }

--- a/docs/research/assessing_biodiversity_and_threatened_species_on_the_gbr.md
+++ b/docs/research/assessing_biodiversity_and_threatened_species_on_the_gbr.md
@@ -1,6 +1,6 @@
 ---
 classes: wide
-title: Biodiversity and threatened species
+title: Biodiversity and Threatened Species
 ---
 
 The significance of the GBR for dugongs and turtles was one of the reasons for its World Heritage listing. Research reveals green sea turtles and dugongs play a crucial role in protecting the health of the Great Barrier Reef, by helping vital seagrass meadows flourish. To enhance the protection of our iconic marine turtles and dugong in Far North Queensland and the Torres Strait, the Australian Government has committed $5.3 million over three years for delivery of a Dugong and Turtle Protection Plan under the Reef 2050 Plan and Reef Trust. The plan addresses threatening processes that impact on the long-term recovery and survival of these protected migratory species.
@@ -19,9 +19,9 @@ Daniel Gonzales Paredes
     </figure>
 </div>
 
-Researchers are using eReefs models as part of their dugong surveys along the GBR. The chance of spotting dugongs from the aerial surveys depends on the depth of the water, which varies with tides. To get accurate tide levels, JCU researchers are using the eReefs hydrodynamic model to find the height of the water at each dugong observation. This height is combined with the known bathymetry to calculate the water depth, which is then used to compensate for the depth bias, allowing for more accurate modelling of the distribution of the dugongs and their population estimates along the Queensland coastline. 
- 
-As part of her PhD Emily Wester (JCU) is studying the fine-scale habitat use of green turtles in the Gladstone region to better understand the reasons behind the movement of the tracked animals, she needed understand the environmental conditions that might be driving their behaviour. eReefs provided a detailed and consistent source of information about ocean hydrodynamics, such as temperature, salinity, and currents, along biochemical variables like daily turbidity and seagrass production. For her analysis, she needed these environmental conditions for over 150,000 data points (lat/long/time). The eReefs team collaborated with Emily to develop a programmatic solution to extract all the data she needed for her analysis. 
+Researchers are using eReefs models as part of their dugong surveys along the GBR. The chance of spotting dugongs from the aerial surveys depends on the depth of the water, which varies with tides. To get accurate tide levels, JCU researchers are using the eReefs hydrodynamic model to find the height of the water at each dugong observation. This height is combined with the known bathymetry to calculate the water depth, which is then used to compensate for the depth bias, allowing for more accurate modelling of the distribution of the dugongs and their population estimates along the Queensland coastline.
+
+As part of her PhD Emily Wester (JCU) is studying the fine-scale habitat use of green turtles in the Gladstone region to better understand the reasons behind the movement of the tracked animals, she needed understand the environmental conditions that might be driving their behaviour. eReefs provided a detailed and consistent source of information about ocean hydrodynamics, such as temperature, salinity, and currents, along biochemical variables like daily turbidity and seagrass production. For her analysis, she needed these environmental conditions for over 150,000 data points (lat/long/time). The eReefs team collaborated with Emily to develop a programmatic solution to extract all the data she needed for her analysis.
 
 ## Outcomes and Impact
 - Better target where and when to survey

--- a/docs/research/publications/case-studies.md
+++ b/docs/research/publications/case-studies.md
@@ -8,8 +8,11 @@ Evaluations related to eReefs and its impact:
 - 2024-11 [RTI: CSIRO's Research Impact in the Great Barrier Reef](https://www.csiro.au/-/media/Environment/files/Great-Barrier-Reef/CSIRO-GBR-Evaluation-Findings-Report_Nov-2024_FINAL.pdf)
   > The review found CSIRO’s Great Barrier Reef research portfolio is well-aligned with overarching Reef 2050 goals, and that collaborative engagement is critical to successful scientific reef management.
 
+- 2024-09 [Protecting the Great Barrier Reef with eReefs, Powered by Nectar](https://ardc.edu.au/case-study/protecting-the-great-barrier-reef-with-ereefs-powered-by-nectar/)
+  > Nectar’s cloud infrastructure empowers Australian researchers to tackle complex challenges through platforms like eReefs
+
 - 2018-05 [Streamlining CSIRO’s research for the Great Barrier Reef](https://www.csiro.au/-/media/LWF/Files/18-00193_LWReviewCaseStudy12pp_GBR_180503.pdf)
-  > CSIRO is helping create an enabling environment that fosters a broad based set of partnerships. These partnerships prioritise and collaborate on critical research pathways that underpin resilience based management of the GBR well into the future. 
+  > CSIRO is helping create an enabling environment that fosters a broad based set of partnerships. These partnerships prioritise and collaborate on critical research pathways that underpin resilience based management of the GBR well into the future.
 
 - 2016-06 [Ensuring a vital future for the Great Barrier Reef](https://www.csiro.au/-/media/About/Files/Impact-case-studies/2016/ICS-eREEFS-PLATFORM.pdf)
   > One-pager summarising the findings of the Acil Allen case study for which the full version is linked below.

--- a/docs/research/publications/web-applications.md
+++ b/docs/research/publications/web-applications.md
@@ -1,6 +1,6 @@
 ---
 classes: wide
-title: eReefs Web Applications
+title: Web Applications
 #toc: true
 #toc_sticky: true
 ---

--- a/docs/research/relocatable-fine-scale-coastal-models.md
+++ b/docs/research/relocatable-fine-scale-coastal-models.md
@@ -3,7 +3,7 @@ classes: wide
 title: Relocatable Coastal Modelling (RECOM)
 ---
 
-The Relocatable Estuary COastal Model (RECOM) is an interactive web based modelling tool developed by CSIRO. It allows users to define a fine-scale resolution grid in a local area of interest and is driven by the larger scale GBR4 and GBR1 models. It is full featured in terms of running the hydrodynamics, sediment transport and BGC models. Custom data, such as bathymetry, coastlines and flow data may be supplied by the user. The higher resolution (~100's of m) of the grids enables the model to capture more of the local dynamics that may be missing from the broader regional models.
+The RElocatable COastal Model (RECOM) is an interactive web based modelling tool developed by CSIRO. It allows users to define a fine-scale resolution grid in a local area of interest and is driven by the larger scale GBR4 and GBR1 models. It is full featured in terms of running the hydrodynamics, sediment transport and BGC models. Custom data, such as bathymetry, coastlines and flow data may be supplied by the user. The higher resolution (~100's of m) of the grids enables the model to capture more of the local dynamics that may be missing from the broader regional models.
 
 In the previous eReefs project, it has mostly been used as an offshore downscaling tool. [Here are some previous applications of RECOM](https://research.csiro.au/ereefs/models/models-about/recom/)
 

--- a/docs/research/relocatable-fine-scale-coastal-models.md
+++ b/docs/research/relocatable-fine-scale-coastal-models.md
@@ -1,9 +1,9 @@
 ---
 classes: wide
-title: RElocatable Coastal Ocean Model (RECOM)
+title: Relocatable Coastal Modelling (RECOM)
 ---
 
-RECOM is an interactive web based modelling tool. It allows users to define a fine-scale resolution grid in a local area of interest and is driven by the larger scale GBR4 and GBR1 models. It is full featured in terms of running the hydrodynamics, sediment transport and BGC models. Custom data, such as bathymetry, coastlines and flow data may be supplied by the user. The higher resolution (~100's of m) of the grids enables the model to capture more of the local dynamics that may be missing from the broader regional models.
+The Relocatable Estuary COastal Model (RECOM) is an interactive web based modelling tool developed by CSIRO. It allows users to define a fine-scale resolution grid in a local area of interest and is driven by the larger scale GBR4 and GBR1 models. It is full featured in terms of running the hydrodynamics, sediment transport and BGC models. Custom data, such as bathymetry, coastlines and flow data may be supplied by the user. The higher resolution (~100's of m) of the grids enables the model to capture more of the local dynamics that may be missing from the broader regional models.
 
 In the previous eReefs project, it has mostly been used as an offshore downscaling tool. [Here are some previous applications of RECOM](https://research.csiro.au/ereefs/models/models-about/recom/)
 

--- a/docs/research/supporting_the_crown_of_thorns_starfish_control_and_innovation_program.md
+++ b/docs/research/supporting_the_crown_of_thorns_starfish_control_and_innovation_program.md
@@ -1,6 +1,6 @@
 ---
 classes: wide
-title: Crown of Thorns Starfish Control and Innovation Program
+title: COTS Control and Innovation Program
 ---
 
 Recurrent outbreaks of the crown-of-thorns starfish (COTS) along the GBR is a significant management issue now requiring active control programs to limit this coral predator to ecologically sustainable levels and re-establish coral growth and recovery. The Crown of Thorns Starfish Control and Innovation program (CCIP) is a research initiative that is boosting capacity to predict, detect and respond to COTS outbreaks at scale across the Great Barrier Reef.
@@ -17,9 +17,9 @@ For the past 40 years, the "terrestrial run-off" hypothesis has been a leading h
 </div>
 
 ## eReefs Products used
-eReefs model scenario outputs were used to test the terrestrial run-off hypothesis enabling the researchers to examine whether reductions of anthropogenic catchment loads are likely to result in improved water quality in the outbreak initiation zone during the COTS larval period.  
+eReefs model scenario outputs were used to test the terrestrial run-off hypothesis enabling the researchers to examine whether reductions of anthropogenic catchment loads are likely to result in improved water quality in the outbreak initiation zone during the COTS larval period.
 
-Analysis of eReefs scenarios found that that riverine nutrient loads are a minor control on planktonic biomass in the COTS initiation zone relative to other forcing, i.e. ocean and atmospheric processes. These results imply that even the most aggressive land management options will not substantially improve water quality in the initiation zone, despite improving nearshore water quality more generally. 
+Analysis of eReefs scenarios found that that riverine nutrient loads are a minor control on planktonic biomass in the COTS initiation zone relative to other forcing, i.e. ocean and atmospheric processes. These results imply that even the most aggressive land management options will not substantially improve water quality in the initiation zone, despite improving nearshore water quality more generally.
 
 <div style="max-width: 90%; margin: auto;">
     <figure>
@@ -31,9 +31,9 @@ Analysis of eReefs scenarios found that that riverine nutrient loads are a minor
 </div>
 
 ## Outcomes and Impact
-- Study results indicate that there will be an ongoing need for direct COTS control measures (e.g., culling). 
+- Study results indicate that there will be an ongoing need for direct COTS control measures (e.g., culling).
 - Findings also show that a fundamental shift in research directions will be essential to understanding environmental drivers of COTS outbreaks and identifying proactive control strategies. These directions include further development of eReefs scenarios and observations to assess how COTS life cycles and outbreaks are influenced by marine and atmospheric forcing.
-- Additional research is needed on ecological controls, including fisheries management strategies, which have recently been linked to COTS densities. 
+- Additional research is needed on ecological controls, including fisheries management strategies, which have recently been linked to COTS densities.
 
 ## Related Resources
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -118,4 +118,4 @@ Our featured *eReefs* software includes:
 
 # Impact Evaluations
 
-How do we know if *eReefs* is worth the effort and funding invested in it over the years? Read independent evaluations of the impact of *eReefs* and related research programs [here](/research/publications/software.html).
+How do we know if *eReefs* is worth the effort and funding invested in it over the years?  [Read independent evaluations of the impact of *eReefs* and related research programs here](/research/publications/case-studies.html).


### PR DESCRIPTION
Fix a broken link on the main tools page (to the impact evaluations page).
Add a missing case study to the impact evaluations page.
Increase the title-font size to make better use of available space.
Tweak some page titles to match the text used in the navigation sidebase (with the bonus that those titles now fit on one line at the new font size)